### PR TITLE
Enable Better Error Handling

### DIFF
--- a/tensformation/receiver.go
+++ b/tensformation/receiver.go
@@ -73,7 +73,7 @@ func (recv *Receiver) receive(ctx context.Context, e cloudevents.Event) *cloudev
 	err = event.SetData(cloudevents.ApplicationJSON, tfResponse)
 	if err != nil {
 		log.Print(err)
-		return emitErrorEvent("wrong event type", "settingCEData")
+		return emitErrorEvent(err.Error(), "settingCEData")
 	}
 
 	return &event

--- a/tensformation/receiver.go
+++ b/tensformation/receiver.go
@@ -39,32 +39,29 @@ const (
 	response             = "io.triggermesh.transformations.s3-tensorflow.response"
 )
 
-const eventSource = "io.triggermesh.transformations.s3-tensorflow"
-
 func (recv *Receiver) receive(ctx context.Context, e cloudevents.Event) *cloudevents.Event {
 	log.Printf("Processing event from source %q", e.Source())
 	if typ := e.Type(); typ != s3ObjectCreatedEvent {
 		fmt.Println("wrong event type")
-		return nil
+		return emitErrorEvent("wrong event type", "wrongEventType")
 	}
 
 	req := &S3Event{}
 	if err := e.DataAs(&req); err != nil {
 		log.Print(err)
-		return nil
+		return emitErrorEvent(err.Error(), "unmarshalingEvent")
 	}
 
 	image, err := recv.downloadFromS3Bucket(req)
 	if err != nil {
 		log.Print(err)
-		return nil
+		return emitErrorEvent(err.Error(), "downloadingFromS3")
 	}
 
-	// Send data to TensorflowService
 	err, tfResponse := recv.makeTensorflowRequest(image)
 	if err != nil {
 		log.Print(err)
-		return nil
+		return emitErrorEvent(err.Error(), "requestingFromTensorflow")
 	}
 
 	url := "https://" + req.S3.Bucket.Name + ".s3." + recv.region + ".amazonaws.com/" + req.S3.Object.Key
@@ -76,10 +73,25 @@ func (recv *Receiver) receive(ctx context.Context, e cloudevents.Event) *cloudev
 	err = event.SetData(cloudevents.ApplicationJSON, tfResponse)
 	if err != nil {
 		log.Print(err)
-		return nil
+		return emitErrorEvent("wrong event type", "settingCEData")
 	}
 
 	return &event
+}
+
+func emitErrorEvent(er string, source string) *cloudevents.Event {
+	responseEvent := cloudevents.NewEvent(cloudevents.VersionV1)
+	responseEvent.SetType(response + ".error")
+	responseEvent.SetSource(source)
+	responseEvent.SetTime(time.Now())
+	err := responseEvent.SetData(cloudevents.ApplicationJSON, er)
+	if err != nil {
+		log.Print(err)
+		return nil
+	}
+
+	return &responseEvent
+
 }
 
 // downloadFromS3Bucket returns a base64 encoded string of the new image at s3
@@ -124,9 +136,7 @@ func (recv *Receiver) makeTensorflowRequest(image string) (error, []byte) {
 	reqBody := &TensorflowRequest{
 		Instances: []struct {
 			B64 string "json:\"b64\""
-		}{struct {
-			B64 string "json:\"b64\""
-		}{B64: image}},
+		}{{B64: image}},
 	}
 
 	b, err := json.Marshal(reqBody)


### PR DESCRIPTION
When an error occurs, tensformation will now emit an event of type `io.triggermesh.transformations.s3-tensorflow.response.error`. This event will contain the error as the payload and a reference to where the error occurred in the event source. See below for two example error events.

```
Ce-Id: 2b502eb5-28c5-4359-b0fc-a695d730c04b
Ce-Source: wrongEventType
Ce-Specversion: 1.0
Ce-Time: 2021-07-01T21:22:00.102625Z
Ce-Type: io.triggermesh.transformations.s3-tensorflow.response.error
Content-Length: 18
Content-Type: application/json
Date: Thu, 01 Jul 2021 21:22:00 GMT

"wrong event type"
```

```
Ce-Id: c128250d-0035-4a4a-bbeb-e6b986a42097
Ce-Source: downloadingFromS3
Ce-Specversion: 1.0
Ce-Time: 2021-07-01T21:22:51.756772Z
Ce-Type: io.triggermesh.transformations.s3-tensorflow.response.error
Content-Length: 34
Content-Type: application/json
Date: Thu, 01 Jul 2021 21:22:51 GMT

"open : no such file or directory"
```

Please note the `Ce-Source` changes depending on what section of the codebase caused the error to occur. 
Probably assigning the source to this will cause some debate later down the road, but for now, I think this method will benefit us in tracking down future bugs more effectively. 