### PR TITLE
Updates Example Manifest to Include Debugging Features

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -140,39 +140,6 @@ spec:
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-    name: all-display
-spec:
-  template:
-    metadata:
-      annotations: {}
-      labels: {}
-    spec:
-      containers:
-       -  image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:46d5a66f300c3ced590835d379a0e9badf413ae7ab60f21a2550ecedbc9eb9d3
-
-# OR if you want sockeye 
-# docker.io/n3wscott/sockeye:v0.5.0@sha256:64c22fe8688a6bb2b44854a07b0a2e1ad021cd7ec52a377a6b135afed5e9f5d2
-
----
-
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-    name: all-display-trigger
-spec:
-    broker: default
-    filter: {}
-    subscriber:
-        ref:
-            apiVersion: serving.knative.dev/v1
-            kind: Service
-            name: all-display
-
----
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
   name: tf-inference-server
 spec:
   template:
@@ -198,3 +165,108 @@ spec:
             memory: 2Gi
       timeoutSeconds: 300
       containerConcurrency: 2
+
+---
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+    name: all-display
+spec:
+  template:
+    spec:
+      containers:
+       -  image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:46d5a66f300c3ced590835d379a0e9badf413ae7ab60f21a2550ecedbc9eb9d3
+
+# OR if you want sockeye 
+# docker.io/n3wscott/sockeye:v0.5.0@sha256:64c22fe8688a6bb2b44854a07b0a2e1ad021cd7ec52a377a6b135afed5e9f5d2
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+    name: all-display-trigger
+spec:
+    broker: default
+    subscriber:
+        ref:
+            apiVersion: serving.knative.dev/v1
+            kind: Service
+            name: all-display
+
+---
+# Used to monitor for any errors that may occur within tensformation or tensorflow_client
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+    name: error-display
+spec:
+  template:
+    spec:
+      containers:
+       -  image: docker.io/n3wscott/sockeye:v0.5.0@sha256:64c22fe8688a6bb2b44854a07b0a2e1ad021cd7ec52a377a6b135afed5e9f5d2
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+    name: error-display-tensformation
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: io.triggermesh.transformations.s3-tensorflow.response.error
+  subscriber:
+      ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: error-display
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+    name: error-display-tensorflow-client
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: io.triggermesh.functions.tensorflow.client.response.error
+  subscriber:
+      ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: error-display
+
+---
+
+# Used to monitor for events that occur when a plate is not recognized in an image. 
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+    name: no-plateid-display
+spec:
+  template:
+    spec:
+      containers:
+       -  image: docker.io/n3wscott/sockeye:v0.5.0@sha256:64c22fe8688a6bb2b44854a07b0a2e1ad021cd7ec52a377a6b135afed5e9f5d2
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+    name: no-plateid-display
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: io.triggermesh.functions.tensorflow.client.response.noid
+  subscriber:
+      ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: no-plateid-display


### PR DESCRIPTION
* `error-display` has been aded to the manifest, with its associated triggers. Allowing for a sockeye to monitor for possible errors that may occur within tensformation or the client.

* `no-plateid-display` has been added to the manifest, with its associated triggers. Allowing for a sockeye to monitor when plates are not matched ( I would see this being replaced with another google sheet/sqs/etc to be re-consumed at a later point)

How to use sockeye:

After a sockeye pod is deployed, retrieve the public address with:
```
kubectl -n demo get ksvc
NAME                  URL                                                 LATESTCREATED               LATESTREADY                 READY   REASON
all-display           https://all-display.jeff.k.triggermesh.io           all-display-00001           all-display-00001           True
error-display         https://error-display.jeff.k.triggermesh.io         error-display-00001         error-display-00001         True
no-plateid-display    https://no-plateid-display.jeff.k.triggermesh.io    no-plateid-display-00001    no-plateid-display-00001    True
tensformation         https://tensformation.jeff.k.triggermesh.io         tensformation-00001         tensformation-00001         True
tensorflow-client     https://tensorflow-client.jeff.k.triggermesh.io     tensorflow-client-00001     tensorflow-client-00001     True
tf-inference-server   https://tf-inference-server.jeff.k.triggermesh.io   tf-inference-server-00001   tf-inference-server-00001   True
```

From the results note the url of the sockeye display and navigate to this url in your browser.

Note: You might have to swap between `http` & `https` because sometimes it behaves odd.