### PR TITLE
add apt-get flags to disable installation of extra packages

### DIFF
--- a/tensorflow_client/Dockerfile
+++ b/tensorflow_client/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7-slim
 
 RUN apt-get update && apt-get install -y \
+    --no-install-recommends --no-install-suggests \
     python3-opencv \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reduces the on-disk image size by 280MiB resulting in a image size of 3 GiB

@JeffNeff please note these changes are largely untested. please give them a test prior to merge